### PR TITLE
Fix defender selection count logic

### DIFF
--- a/addons/sourcemod/scripting/mitm/queue.sp
+++ b/addons/sourcemod/scripting/mitm/queue.sp
@@ -156,19 +156,20 @@ void Queue_SelectDefenders()
 	{
 		players.Sort(Sort_Random, Sort_Integer);
 		
-		for (int i = 0; i < players.Length; i++)
-		{
-			int client = players.Get(i);
-			
-			// Keep filling slots until our quota is met
-			if (iDefenderCount++ >= iReqDefenderCount)
-				break;
-			
-			CTFPlayer(client).SetAsDefender();
-			CPrintToChat(client, "%s %t %t", PLUGIN_TAG, "SelectedAsDefender_Forced", "Queue_NotReset");
-			
-			players.Erase(i);
-		}
+               for (int i = 0; i < players.Length; i++)
+               {
+                       int client = players.Get(i);
+
+                       // Keep filling slots until our quota is met
+                       if (iDefenderCount >= iReqDefenderCount)
+                               break;
+
+                       CTFPlayer(client).SetAsDefender();
+                       CPrintToChat(client, "%s %t %t", PLUGIN_TAG, "SelectedAsDefender_Forced", "Queue_NotReset");
+
+                       players.Erase(i);
+                       ++iDefenderCount;
+               }
 	}
 	
 	if (iDefenderCount < iReqDefenderCount)

--- a/addons/sourcemod/scripting/mitm/util.sp
+++ b/addons/sourcemod/scripting/mitm/util.sp
@@ -1146,16 +1146,17 @@ void SelectRandomDefenders()
 		if (!CTFPlayer(client).IsValidDefender())
 			continue;
 		
-		// Keep filling slots until our quota is met
-		if (iDefenderCount++ >= iReqDefenderCount)
-			break;
-		
-		CTFPlayer(client).SetAsDefender();
-		CTFPlayer(client).ResetDefenderPriority();
-		CPrintToChat(client, "%s %t", PLUGIN_TAG, "SelectedAsDefender");
-		
-		players.Erase(i);
-	}
+               // Keep filling slots until our quota is met
+               if (iDefenderCount >= iReqDefenderCount)
+                       break;
+
+               CTFPlayer(client).SetAsDefender();
+               CTFPlayer(client).ResetDefenderPriority();
+               CPrintToChat(client, "%s %t", PLUGIN_TAG, "SelectedAsDefender");
+
+               players.Erase(i);
+               ++iDefenderCount;
+       }
 	
 	// We have less defenders than we wanted.
 	// Pick random players, regardless of their defender preference.
@@ -1165,16 +1166,17 @@ void SelectRandomDefenders()
 		{
 			int client = players.Get(i);
 			
-			// Keep filling slots until our quota is met
-			if (iDefenderCount++ >= iReqDefenderCount)
-				break;
-			
-			CTFPlayer(client).SetAsDefender();
-			CPrintToChat(client, "%s %t", PLUGIN_TAG, "SelectedAsDefender_Forced");
-			
-			players.Erase(i);
-		}
-	}
+                       // Keep filling slots until our quota is met
+                       if (iDefenderCount >= iReqDefenderCount)
+                               break;
+
+                       CTFPlayer(client).SetAsDefender();
+                       CPrintToChat(client, "%s %t", PLUGIN_TAG, "SelectedAsDefender_Forced");
+
+                       players.Erase(i);
+                       ++iDefenderCount;
+               }
+       }
 	
 	for (int i = 0; i < players.Length; i++)
 	{


### PR DESCRIPTION
## Summary
- fix off-by-one errors when filling defender slots

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68413504595c8333bf64495216190e6a