### PR TITLE
Add models to spectators

### DIFF
--- a/addons/sourcemod/scripting/mitm.sp
+++ b/addons/sourcemod/scripting/mitm.sp
@@ -39,7 +39,7 @@
 // Uncomment this for diagnostic messages in server console (very verbose)
 // #define DEBUG
 
-#define PLUGIN_VERSION	"1.1.8"
+#define PLUGIN_VERSION	"1.2.0"
 
 // Global entities
 CMannVsMachineStats g_pMVMStats = view_as<CMannVsMachineStats>(INVALID_ENT_REFERENCE);

--- a/addons/sourcemod/scripting/mitm/data.sp
+++ b/addons/sourcemod/scripting/mitm/data.sp
@@ -1936,6 +1936,7 @@ methodmap CTFPlayer < CBaseCombatCharacter
 				text.KeyValueVector("angles", angles);
 				text.KeyValueInt("orientation", 1);
 				text.KeyValueInt("textsize", 5);
+				text.KeyValueInt("rainbow", GetUserAdmin(this.index) != INVALID_ADMIN_ID ? 1 : 0);
 				text.SetPropEnt(Prop_Send, "m_hOwnerEntity", this);
 				text.Spawn();
 				

--- a/addons/sourcemod/scripting/mitm/data.sp
+++ b/addons/sourcemod/scripting/mitm/data.sp
@@ -74,7 +74,7 @@ static int m_preferences[MAXPLAYERS + 1];
 static Party m_party[MAXPLAYERS + 1];
 static bool m_isPartyMenuActive[MAXPLAYERS + 1];
 static int m_spawnDeathCount[MAXPLAYERS + 1];
-static int m_cameraEntity[MAXPLAYERS + 1];
+static int m_hCameraEntity[MAXPLAYERS + 1];
 
 methodmap CTFPlayer < CBaseCombatCharacter
 {
@@ -503,15 +503,15 @@ methodmap CTFPlayer < CBaseCombatCharacter
 		}
 	}
 
-	property int m_cameraEntity
+	property int m_hCameraEntity
 	{
 		public get()
 		{
-			return m_cameraEntity[this.index];
+			return m_hCameraEntity[this.index];
 		}
 		public set(int hCameraEntity)
 		{
-			m_cameraEntity[this.index] = hCameraEntity;
+			m_hCameraEntity[this.index] = hCameraEntity;
 		}
 	}
 	
@@ -1913,7 +1913,7 @@ methodmap CTFPlayer < CBaseCombatCharacter
 
 	public void CreateCamera()
 	{
-		if (IsValidEntity(this.m_cameraEntity))
+		if (IsValidEntity(this.m_hCameraEntity))
 			return;
 		
 		float origin[3], angles[3];
@@ -1923,7 +1923,7 @@ methodmap CTFPlayer < CBaseCombatCharacter
 		CBaseEntity prop = CBaseEntity(CreateEntityByName("prop_dynamic"));
 		if (prop.IsValid())
 		{
-			prop.KeyValue("model", "models/props_mvm/mvm_human_skull.mdl");
+			prop.KeyValue("model", CAMERA_MODEL);
 			prop.KeyValueVector("origin", origin);
 			prop.KeyValueVector("angles", angles);
 			prop.SetPropEnt(Prop_Send, "m_hOwnerEntity", this);
@@ -1953,14 +1953,14 @@ methodmap CTFPlayer < CBaseCombatCharacter
 
 			prop.SetNextThink(GetGameTime());
 			
-			this.m_cameraEntity = EntIndexToEntRef(prop);
+			this.m_hCameraEntity = EntIndexToEntRef(prop);
 		}
 	}
 
 	public void DestroyCamera()
 	{
-		if (IsValidEntity(this.m_cameraEntity))
-			RemoveEntity(this.m_cameraEntity);
+		if (IsValidEntity(this.m_hCameraEntity))
+			RemoveEntity(this.m_hCameraEntity);
 	}
 	
 	public void Init()
@@ -2007,7 +2007,7 @@ methodmap CTFPlayer < CBaseCombatCharacter
 		this.m_party = NULL_PARTY;
 		this.m_isPartyMenuActive = false;
 		this.m_spawnDeathCount = 0;
-		this.m_cameraEntity = INVALID_ENT_REFERENCE;
+		this.m_hCameraEntity = INVALID_ENT_REFERENCE;
 		
 		m_invaderName[this.index][0] = EOS;
 		m_prevName[this.index][0] = EOS;

--- a/addons/sourcemod/scripting/mitm/events.sp
+++ b/addons/sourcemod/scripting/mitm/events.sp
@@ -65,11 +65,11 @@ static Action EventHook_PlayerTeam(Event event, const char[] name, bool dontBroa
 	bool bSilent = team != TFTeam_Defenders;
 	event.SetInt("silent", bSilent);
 	
+	CTFPlayer player = CTFPlayer(client);
+
 	// CTFBot::ChangeTeam
 	if (IsMannVsMachineMode())
 	{
-		CTFPlayer player = CTFPlayer(client);
-		
 		player.SetPrevMission(NO_MISSION);
 		player.ClearAllAttributes();
 		// Clear Sound
@@ -82,9 +82,9 @@ static Action EventHook_PlayerTeam(Event event, const char[] name, bool dontBroa
 	}
 
 	if (team == TFTeam_Spectator)
-		CTFPlayer(client).CreateCamera();
+		player.CreateCamera();
 	else
-		CTFPlayer(client).DestroyCamera();
+		player.DestroyCamera();
 
 	return Plugin_Changed;
 }

--- a/addons/sourcemod/scripting/mitm/events.sp
+++ b/addons/sourcemod/scripting/mitm/events.sp
@@ -78,7 +78,12 @@ static Action EventHook_PlayerTeam(Event event, const char[] name, bool dontBroa
 			CTFPlayer(client).ResetInvaderName();
 		}
 	}
-	
+
+	if (team == TFTeam_Spectator)
+		CTFPlayer(client).CreateCamera();
+	else
+		CTFPlayer(client).DestroyCamera();
+
 	return Plugin_Changed;
 }
 

--- a/addons/sourcemod/scripting/mitm/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mitm/sdkhooks.sp
@@ -251,30 +251,29 @@ Action SDKHookCB_EntityGlow_SetTransmit(int entity, int client)
 
 void SDKHookCB_Text_ThinkPost(int entity)
 {
-	CBaseEntity text = CBaseEntity(entity);
-
-	CTFPlayer owner = CTFPlayer(text.GetPropEnt(Prop_Send, "m_hOwnerEntity"));
-	if (!owner.IsValid())
+	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+	if (owner == -1)
 		return;
-
+	
 	char name[MAX_NAME_LENGTH];
 	if (!GetClientName(owner, name, sizeof(name)))
 		return;
 	
-	text.KeyValue("message", name);
+	DispatchKeyValue(entity, "message", name);
 	
-	CBaseEntity parent = CBaseEntity(text.GetPropEnt(Prop_Data, "m_hMoveParent"));
-	if (!parent.IsValid())
+	int parent = GetEntPropEnt(entity, Prop_Data, "m_hMoveParent");
+	if (parent == -1)
 		return;
-
+	
 	float pos[3], maxs[3];
-	parent.WorldSpaceCenter(pos);
-	parent.GetPropVector(Prop_Data, "m_vecMaxs", maxs);
+	CBaseEntity(parent).WorldSpaceCenter(pos);
+	GetEntPropVector(parent, Prop_Data, "m_vecMaxs", maxs);
+	
 	pos[2] += maxs[2];
 	pos[2] += 8.0;
-	text.SetAbsOrigin(pos);
+	DispatchKeyValueVector(entity, "origin", pos);
 	
-	text.SetNextThink(GetGameTime());
+	CBaseEntity(entity).SetNextThink(GetGameTime());
 }
 
 Action SDKHookCB_Camera_SetTransmit(int entity, int client)
@@ -282,22 +281,22 @@ Action SDKHookCB_Camera_SetTransmit(int entity, int client)
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
 	if (owner == -1)
 		return Plugin_Handled;
-
+	
 	if (owner == client)
 		return Plugin_Handled;
 	
 	if (CTFPlayer(owner).HasPreference(PREF_SPECTATOR_MODE))
 		return Plugin_Handled;
-
+	
 	if (GetEntProp(owner, Prop_Data, "m_iTeamNum") != GetClientTeam(client))
 		return Plugin_Handled;
-
+	
 	if (!IsClientObserver(client))
 		return Plugin_Handled;
 	
 	if (GetEntProp(owner, Prop_Send, "m_iObserverMode") != OBS_MODE_ROAMING)
 		return Plugin_Handled;
-
+	
 	return Plugin_Continue;
 }
 
@@ -309,13 +308,13 @@ void SDKHookCB_Camera_ThinkPost(int entity)
 		RemoveEntity(entity);
 		return;
 	}
-
+	
 	float origin[3], angles[3];
 	GetClientEyePosition(owner, origin);
 	GetClientEyeAngles(owner, angles);
-
+	
 	DispatchKeyValueVector(entity, "origin", origin);
 	DispatchKeyValueVector(entity, "angles", angles);
-
+	
 	CBaseEntity(entity).SetNextThink(GetGameTime());
 }

--- a/addons/sourcemod/scripting/mitm/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mitm/sdkhooks.sp
@@ -249,33 +249,6 @@ Action SDKHookCB_EntityGlow_SetTransmit(int entity, int client)
 	return Plugin_Handled;
 }
 
-void SDKHookCB_Text_ThinkPost(int entity)
-{
-	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
-	if (owner == -1)
-		return;
-	
-	char name[MAX_NAME_LENGTH];
-	if (!GetClientName(owner, name, sizeof(name)))
-		return;
-	
-	DispatchKeyValue(entity, "message", name);
-	
-	int parent = GetEntPropEnt(entity, Prop_Data, "m_hMoveParent");
-	if (parent == -1)
-		return;
-	
-	float pos[3], maxs[3];
-	CBaseEntity(parent).WorldSpaceCenter(pos);
-	GetEntPropVector(parent, Prop_Data, "m_vecMaxs", maxs);
-	
-	pos[2] += maxs[2];
-	pos[2] += 8.0;
-	DispatchKeyValueVector(entity, "origin", pos);
-	
-	CBaseEntity(entity).SetNextThink(GetGameTime());
-}
-
 Action SDKHookCB_Camera_SetTransmit(int entity, int client)
 {
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -315,6 +288,33 @@ void SDKHookCB_Camera_ThinkPost(int entity)
 	
 	DispatchKeyValueVector(entity, "origin", origin);
 	DispatchKeyValueVector(entity, "angles", angles);
+	
+	CBaseEntity(entity).SetNextThink(GetGameTime());
+}
+
+void SDKHookCB_Text_ThinkPost(int entity)
+{
+	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+	if (owner == -1)
+		return;
+	
+	char name[MAX_NAME_LENGTH];
+	if (!GetClientName(owner, name, sizeof(name)))
+		return;
+	
+	DispatchKeyValue(entity, "message", name);
+	
+	int parent = GetEntPropEnt(entity, Prop_Data, "m_hMoveParent");
+	if (parent == -1)
+		return;
+	
+	float pos[3], maxs[3];
+	CBaseEntity(parent).WorldSpaceCenter(pos);
+	GetEntPropVector(parent, Prop_Data, "m_vecMaxs", maxs);
+	
+	pos[2] += maxs[2];
+	pos[2] += 8.0;
+	DispatchKeyValueVector(entity, "origin", pos);
 	
 	CBaseEntity(entity).SetNextThink(GetGameTime());
 }

--- a/addons/sourcemod/scripting/mitm/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mitm/sdkhooks.sp
@@ -314,6 +314,7 @@ void SDKHookCB_Text_ThinkPost(int entity)
 	
 	pos[2] += maxs[2];
 	pos[2] += 8.0;
+
 	DispatchKeyValueVector(entity, "origin", pos);
 	
 	CBaseEntity(entity).SetNextThink(GetGameTime());

--- a/addons/sourcemod/scripting/mitm/shareddefs.sp
+++ b/addons/sourcemod/scripting/mitm/shareddefs.sp
@@ -22,6 +22,8 @@
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 
+#define CAMERA_MODEL	"models/props_mvm/mvm_human_skull.mdl"
+
 #define ZERO_VECTOR	{ 0.0, 0.0, 0.0 }
 
 #define VEC_HULL_MIN	{ -24.0, -24.0, 0.0 }


### PR DESCRIPTION
Adds a skull model to spectators, so players may see eachother pre-wave or during downtime